### PR TITLE
fix(device): send hostname with dhcp request

### DIFF
--- a/src/transport/net/NetworkService.cpp
+++ b/src/transport/net/NetworkService.cpp
@@ -50,8 +50,8 @@ void NetworkService::begin(const DeviceConfig& cfg, bool forceAp,
                            const std::function<void()>& onWait) {
   hostname_ = net::effectiveHostname(cfg.hostname, WiFi.macAddress().c_str());
   WiFi.persistent(true);
-  WiFi.mode(WIFI_STA);
   WiFi.setHostname(hostname_.c_str());
+  WiFi.mode(WIFI_STA);
   // Widest legal channel set (1-13) so an AP on 12 or 13 is visible; the regulatory domain is
   // corrected from the AP's country IE once we associate.
   wifi_country_t country = {};


### PR DESCRIPTION
## What this changes

set hostname before make the dhcp request, not after

## How it was verified

- [x] `pio test -e native` passes
- [x] `pio run -e awtrix` and `pio run -e awtrix_s3` build
- [x] Tested in the simulator (`pio run -e native_sim`)
   tests was failed like in main
- [x] Tested on hardware — board: tc001

## Checklist

- [ ] New behaviour has a host test in `test/`, or it genuinely cannot run off-device
- [ ] `src/core/` stayed portable (no Arduino, FastLED or board headers)
- [ ] Documentation in `docs/` updated for any new field, endpoint or setting
- [ ] Regenerated any checked-in generated file this change invalidates
      (see the table in [CONTRIBUTING.md](../CONTRIBUTING.md))

## Notice

Assisted-By: AI (Claude Sonnet5)