### PR TITLE
Fix review findings: HTTP dir listing, StateStore emit, MelodyPlayer race

### DIFF
--- a/src/core/StateStore.h
+++ b/src/core/StateStore.h
@@ -31,8 +31,11 @@ class StateStore {
   void subscribe(Listener l) { listeners_.push_back(std::move(l)); }
 
   void emit(StateEvent e) {
-    for (auto& l : listeners_)
-      if (l) l(e);
+    // Index-based on purpose: a listener may call subscribe() from inside a callback, and the
+    // resulting push_back would invalidate the iterators of a range-based for loop.
+    const size_t n = listeners_.size();
+    for (size_t i = 0; i < n && i < listeners_.size(); ++i)
+      if (listeners_[i]) listeners_[i](e);
   }
 
  private:

--- a/src/core/apps/SensorFormat.cpp
+++ b/src/core/apps/SensorFormat.cpp
@@ -7,7 +7,7 @@ namespace awtrix {
 
 namespace {
 std::string roundToString(float v, int decimals) {
-  char buf[16];
+  char buf[32];  // room for any 64-bit %ld or high-precision %f, not just sensor ranges
   if (decimals <= 0) {
     snprintf(buf, sizeof(buf), "%ld", std::lround(v));
   } else {

--- a/src/media/GifPlayer.cpp
+++ b/src/media/GifPlayer.cpp
@@ -1,5 +1,6 @@
 #include "media/GifPlayer.h"
 
+#include <algorithm>
 #include <cstring>
 
 #include "media/AssetFile.h"
@@ -79,7 +80,9 @@ GifPlayer::PreDecode GifPlayer::preDecode(bool firstFrameOnly, int maxResidentFr
   const int frameBytes = w_ * h_;
   const int budgetFrames =
       kPreDecodeBudgetBytes / (frameBytes * static_cast<int>(sizeof(uint32_t)));
-  const int maxFrames = maxResidentFrames > 0 ? maxResidentFrames : budgetFrames;
+  // Clamp caller-supplied caps so frameCount * frameBytes can never overflow a 32-bit size_t.
+  const int maxFrames =
+      maxResidentFrames > 0 ? std::min(maxResidentFrames, 4096) : budgetFrames;
   Canvas scratch(w_, h_);
   scratch.clear(0x000000u);
   for (;;) {

--- a/src/persistence/DeviceConfig.cpp
+++ b/src/persistence/DeviceConfig.cpp
@@ -49,7 +49,7 @@ const char* const kLegacyMatrixKeys[] = {"mwidth", "matlay", "mtilew", "morient"
 // firmware simply leaves the newer fields at their compiled-in defaults.
 void DeviceConfig::load() {
   Preferences p;
-  p.begin(kNs, true);
+  if (!p.begin(kNs, true)) return;
 #define X(member, key, secret) cfgGet(p, key, member);
   AWTRIX_CFG_FIELDS(X)
 #undef X
@@ -58,7 +58,7 @@ void DeviceConfig::load() {
 
 void DeviceConfig::save() const {
   Preferences p;
-  p.begin(kNs, false);
+  if (!p.begin(kNs, false)) return;
 #define X(member, key, secret) cfgPut(p, key, member);
   AWTRIX_CFG_FIELDS(X)
 #undef X

--- a/src/sound/MelodyPlayer/melody_player.cpp
+++ b/src/sound/MelodyPlayer/melody_player.cpp
@@ -79,6 +79,8 @@ void MelodyPlayer::play(Melody &melody)
   {
     return;
   }
+  // Same hazard as playAsync(melody, ...): drop a pending ticker callback before the swap.
+  haltPlay();
   melodyState = make_unique<MelodyState>(melody);
   play();
 }
@@ -99,6 +101,12 @@ void releaseTone(MelodyPlayer *player)
 
 void changeTone(MelodyPlayer *player)
 {
+  // The ticker callback can fire on the timer task while the main thread is in stop() or is
+  // swapping melodyState for a new melody — never dereference it unchecked.
+  if (player->melodyState == nullptr)
+  {
+    return;
+  }
   player->melodyState->advance();
   if (player->melodyState->getIndex() + player->melodyState->isSilence() < player->melodyState->melody.getLength())
   {
@@ -207,6 +215,9 @@ void MelodyPlayer::playAsync(Melody &melody, bool loopMelody, void (*callback)(v
   {
     return;
   }
+  // Detach any pending ticker callback before freeing the old state, otherwise changeTone can
+  // run against a melodyState that no longer exists.
+  haltPlay();
   melodyState = make_unique<MelodyState>(melody);
   loop = loopMelody;
   stopCallback = callback;

--- a/src/transport/http/HttpApiServer.cpp
+++ b/src/transport/http/HttpApiServer.cpp
@@ -1134,6 +1134,15 @@ bool HttpApiServer::serveFiles(const Request& req) {
 
   if (req.get) {
     const String dir = server_->hasArg("dir") ? server_->arg("dir") : String("/ICONS");
+    // Same rule as DELETE below: without it ?dir= could enumerate any directory on the flash.
+    // The bare root names carry no trailing slash, so append one for the prefix check.
+    std::string probe(dir.c_str());
+    if (probe.empty() || probe.back() != '/') probe += '/';
+    if (!assets::isServable(probe)) {
+      sendError(400, "invalidPath",
+                "dir must be /ICONS, /MELODIES, /PALETTES or /MP3 and contain no '..'");
+      return true;
+    }
     listDir(dir.c_str());
     return true;
   }


### PR DESCRIPTION
General code-review pass over the firmware. Three confirmed bugs fixed, plus three minor hardening changes.

### Confirmed bugs

- **Unvalidated `dir` parameter in `GET /api/v1/files`** (`HttpApiServer.cpp`) — the GET branch passed the query parameter straight to `listDir()`, while DELETE already validates with `assets::isWritable()`. Any directory on the flash (e.g. `/CONFIG`) could be enumerated. Now validated with `assets::isServable` (a trailing slash is appended so the bare root names like `/ICONS` still pass the prefix rule).
- **Iterator invalidation in `StateStore::emit()`** (`StateStore.h`) — a listener calling `subscribe()` from inside a callback would `push_back` into the vector being iterated by a range-based for loop (UB). Switched to index-based iteration.
- **Race condition in `MelodyPlayer`** (`melody_player.cpp`) — the Ticker callback `changeTone()` (timer task context) dereferenced `melodyState` while the main thread could swap it in `playAsync(melody)` / `play(melody)` or reset it in `stop()`. Now the ticker is detached before the state is replaced, and `changeTone` guards against a null state.

### Minor hardening

- `DeviceConfig::load()/save()`: check the `Preferences::begin()` return value, as `NvsSettings.cpp` already does.
- `GifPlayer::preDecode()`: clamp a caller-supplied `maxResidentFrames` so `frameCount * frameBytes` can never overflow a 32-bit `size_t` (dimensions are already clamped to 32×8 by MicroGif, so this is defense in depth).
- `SensorFormat`: widened the `snprintf` buffer 16 → 32 bytes to fit any 64-bit `%ld` / high-precision `%f`, not just the sensor ranges in use today.

### Validation

- ✅ 1687/1687 native unit tests (`pio test -e native`)
- ✅ `pio run -e native_sim`
- ✅ `pio run -e awtrix` (ESP32 firmware build)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>